### PR TITLE
Fix #8: ID as query parameter instead of path in _delete()

### DIFF
--- a/pyedgeconnect/orch/_appliance_preconfig.py
+++ b/pyedgeconnect/orch/_appliance_preconfig.py
@@ -340,7 +340,7 @@ def delete_preconfig(
     :rtype: bool
     """
     return self._delete(
-        "/gms/appliance/preconfiguration/{}".format(preconfig_id),
+        "/gms/appliance/preconfiguration/?preconfigId={}".format(preconfig_id),
         return_type="bool",
     )
 


### PR DESCRIPTION
#8 

Currently the URL given is incorrect like this:

    return self._delete(
        "/gms/appliance/preconfiguration/{}".format(preconfig_id),
        return_type="bool",
    )
this is incorrect and results in this error:

    [DELETE] /gms/appliance/preconfiguration/8 | Received HTTP 404 | Response text: null for uri: http://hostname.silverpeak.cloud/gms/rest/gms/appliance/preconfiguration/8?source=menu_rest_apis_id

inspecting orchestrator API calls, it should be like so:

    return self._delete(
        "/gms/appliance/preconfiguration/?preconfigId={}".format(preconfig_id),
        return_type="bool",
    )
